### PR TITLE
Fix Google Maps 403 in Electron and ambiguous codesign

### DIFF
--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
     ],
     "afterSign": ".erb/scripts/notarize.js",
     "mac": {
+      "identity": "970E7341A4C23DD9C046A60F16CCF02BDEA7A4BB",
       "target": {
         "target": "default",
         "arch": [

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -36,6 +36,7 @@ import dotenv from 'dotenv';
 import {
   app,
   BrowserWindow,
+  session,
   shell,
   ipcMain,
   type IpcMainInvokeEvent,
@@ -155,6 +156,35 @@ async function enableElectronDebug(): Promise<void> {
   enableDebug();
 }
 
+const GOOGLE_API_URL_FILTER = [
+  '*://*.googleapis.com/*',
+  '*://maps.googleapis.com/*',
+  '*://maps.gstatic.com/*',
+];
+
+/** Electron file:// loads send no Referer; GCP keys with HTTP referrer restrictions return 403. */
+function googleMapsReferer(): string {
+  const override = process.env.GOOGLE_MAPS_REFERER?.trim();
+  if (override) return override;
+  if (process.env.NODE_ENV === 'development') {
+    const port = process.env.PORT || 1212;
+    return `http://localhost:${port}/`;
+  }
+  return 'https://localhost/';
+}
+
+function configureGoogleMapsReferer(): void {
+  const referer = googleMapsReferer();
+  session.defaultSession.webRequest.onBeforeSendHeaders(
+    { urls: GOOGLE_API_URL_FILTER },
+    (details, callback) => {
+      const requestHeaders = { ...details.requestHeaders };
+      requestHeaders.Referer = referer;
+      callback({ requestHeaders });
+    }
+  );
+}
+
 const installExtensions = async (): Promise<void> => {
   const forceDownload = !!process.env.UPGRADE_EXTENSIONS;
   try {
@@ -240,6 +270,7 @@ app.on('window-all-closed', () => {
 app
   .whenReady()
   .then(async () => {
+    configureGoogleMapsReferer();
     await enableElectronDebug();
     await createWindow();
     app.on('activate', () => {

--- a/src/renderer/googleMapsConfig.ts
+++ b/src/renderer/googleMapsConfig.ts
@@ -3,6 +3,14 @@ import type { Library } from '@googlemaps/js-api-loader';
 /** Injected at build time by webpack DefinePlugin from .env. */
 export const GOOGLE_MAPS_API_KEY = __GOOGLE_MAPS_API_KEY__;
 
+/**
+ * Packaged Electron uses file:// (empty Referer → 403). Main process injects a
+ * Referer; whitelist the same value on your API key (HTTP referrers):
+ * - https://localhost/*
+ * - http://localhost:1212/* (dev)
+ * Enable: Maps JavaScript API, Routes API, Places API, Geocoding API.
+ */
+
 /** Required for AdvancedMarkerElement; use DEMO_MAP_ID or a Cloud Console map ID. */
 export const GOOGLE_MAP_ID = 'DEMO_MAP_ID';
 


### PR DESCRIPTION
## Summary

- Injects a `Referer` header on Google Maps / Routes API requests from Electron (`file://` otherwise sends none → 403 with HTTP referrer–restricted API keys).
- Documents required GCP allowlist entries in `googleMapsConfig.ts` (`https://localhost/*`, `http://localhost:1212/*`).
- Pins macOS `Developer ID Application` signing to certificate SHA-1 `970E7341…` to fix ambiguous duplicate certs in login + System keychains during `npm run package`.

## Test plan

- [ ] Add `https://localhost/*` and `http://localhost:1212/*` to API key HTTP referrers; confirm Routes/maps load in dev and packaged app.
- [ ] `npm run package` completes codesign without "ambiguous" identity error.
- [ ] Optional: remove duplicate Developer ID cert from Keychain Access for long-term cleanup.


Made with [Cursor](https://cursor.com)