### PR TITLE
Fix CI mac signing: remove pinned certificate hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "postinstall": "ts-node .erb/scripts/check-native-dep.js && electron-builder install-app-deps && cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.renderer.dev.dll.ts && cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.main.dev.ts",
     "lint": "cross-env NODE_ENV=development eslint . --ext .js,.jsx,.ts,.tsx",
     "package": "ts-node ./.erb/scripts/clean.js dist && npm run build && electron-builder build --publish never",
+    "package:mac": "cross-env CSC_NAME=970E7341A4C23DD9C046A60F16CCF02BDEA7A4BB npm run package",
     "rebuild": "electron-rebuild --parallel --types prod,dev,optional --module-dir release/app",
     "start": "ts-node ./.erb/scripts/check-port-in-use.js && npm run start:renderer",
     "start:main": "cross-env NODE_ENV=development MAIN_WEBPACK_WATCH=true concurrently -k \"webpack --config ./.erb/configs/webpack.config.main.dev.ts\" \"electronmon .\"",
@@ -202,7 +203,6 @@
     ],
     "afterSign": ".erb/scripts/notarize.js",
     "mac": {
-      "identity": "970E7341A4C23DD9C046A60F16CCF02BDEA7A4BB",
       "target": {
         "target": "default",
         "arch": [


### PR DESCRIPTION
## Summary

PR #19 added `mac.identity` with a SHA-1 hash from a **local** keychain to fix ambiguous `codesign` on your Mac. That hash is **not** present on GitHub Actions after importing `CSC_LINK`, so electron-builder logged:

`falling back to ad-hoc signature` → `identityName=-` → notarization rejected all binaries.

This removes the hardcoded `mac.identity` so CI uses the Developer ID cert from `CSC_LINK` / `CSC_KEY_PASSWORD` as before.

For local packaging with duplicate certs in login + System keychains, use:

```bash
npm run package:mac
```

which sets `CSC_NAME` to the local cert hash only for that command.

## Test plan

- [ ] Merge and re-run Publish workflow on `main`
- [ ] Confirm log shows `identityName=Developer ID Application: ...` (not `-`) and notarization succeeds
- [ ] Locally: `npm run package:mac` still signs when ambiguous certs exist


Made with [Cursor](https://cursor.com)