### PR TITLE
Release v1.2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 1.2.1
+
+- Fix CI mac signing (remove local-only certificate hash pin)
+- Inject Google Maps Referer for Electron file:// loads
+- Geocode person address on create and update; mac publish notarization env fixes
+
 # 1.2.0
 
 - Upgrade Electron 23 → 40, electron-builder 26, electron-updater 6

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "standalone-blind",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "version": "1.2.0",
+      "version": "1.2.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A Drving Route Planner",
   "keywords": [
     "electron",

--- a/release/app/package-lock.json
+++ b/release/app/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "blind-ministry",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "blind-ministry",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "hasInstallScript": true,
       "license": "MIT"
     }

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "blind-ministry",
   "productName": "Blind Ministry Routing",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Routing App for Blind Ministry",
   "license": "MIT",
   "author": {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -212,9 +212,9 @@ const createWindow = async (): Promise<void> => {
 
   const options = {
     applicationName: 'Blind Ministry Routing',
-    applicationVersion: '1.2.0',
+    applicationVersion: '1.2.1',
     copyright: '© 2023',
-    version: '1.2.0',
+    version: '1.2.1',
     credits: 'Credits:\n\t• David G. Simmons\n\t• Electron React Boilerplate',
     authors: ['David G. Simmons'],
     website: 'https://github.com/davidgs/standalone-blind',


### PR DESCRIPTION
## Summary

Bump version to **1.2.1** so electron-builder can publish assets to GitHub. v1.2.0 already exists as a **published** release; CI was configured to publish as **draft**, which caused `existing type not compatible with publishing type`.

## Test plan

- [ ] Merge to `main` and confirm Publish workflow uploads DMG/zip/exe to a new `v1.2.1` draft release


Made with [Cursor](https://cursor.com)